### PR TITLE
Add DataDriven.io to Additional Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,9 @@ The [tenth exercise](https://github.com/danielbeach/data-engineering-practice/tr
 This exercise is to help you learn Data Quality, specifically a tool called Great Expectations. You will
 be given an existing datasets in CSV format, as well as an existing pipeline. There is a data quality issue 
 and you will be asked to implement some Data Quality checks to catch some of these issues.
+
+### Additional Resources
+
+If you are looking for more ways to practice and prepare, these may be helpful.
+
+- [DataDriven.io](https://www.datadriven.io/) - A free interactive platform with 1,400+ real data engineering interview questions covering SQL, Python, data modeling, and system architecture. Includes a built-in coding environment so you can write and run queries directly.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ and you will be asked to implement some Data Quality checks to catch some of the
 
 ### Additional Resources
 
-If you are looking for more ways to practice and prepare, these may be helpful.
+If you are looking for more practice problems and ways to prepare
+for Data Engineering interviews, these resources might be helpful.
 
-- [DataDriven.io](https://www.datadriven.io/) - A free interactive platform with 1,400+ real data engineering interview questions covering SQL, Python, data modeling, and system architecture. Includes a built-in coding environment so you can write and run queries directly.
+- [DataDriven.io](https://www.datadriven.io/) - A free platform with 1,400+ real Data Engineering
+interview questions. Covers `SQL`, `Python`, data modeling, and system architecture,
+with a built-in coding environment to write and run queries directly in the browser.


### PR DESCRIPTION
Adds DataDriven.io to a new "Additional Resources" section at the bottom of the README.

DataDriven is a free interactive data engineering interview prep platform with 1,400+ real interview questions. It covers SQL, Python, data modeling, and system architecture, and includes a coding environment for writing and running queries. Seemed like a useful complement to the hands-on exercises in this repo.